### PR TITLE
Use PyTorch CPU only dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+          key: ${{ env.pythonLocation }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,6 @@ jsonparquet/iml*
 .idea/**/dictionaries
 .idea/**/shelf
 
-
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ pyarrow==12.0.0
 redis==4.5.3
 torch==1.9.0+cpu
 transformers
-sentence_transformers==2.2.2 --install-option="--no-deps"
+sentence_transformers==2.2.2 --install-option='--no-deps'
 tqdm==4.64.1
 fakeredis

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ Flask==2.2.3
 pandas==1.5.3
 pyarrow==12.0.0
 redis==4.5.3
-torch==1.9.0+cpu
+-f https://download.pytorch.org/whl/torch_stable.html
+torch==2.0.1+cpu
 transformers
 sentence_transformers==2.2.2
 tqdm==4.64.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ Flask==2.2.3
 pandas==1.5.3
 pyarrow==12.0.0
 redis==4.5.3
-sentence_transformers==2.2.2
+torch==1.9.0+cpu
+transformers
+sentence_transformers==2.2.2 --install-option="--no-deps"
 tqdm==4.64.1
 fakeredis

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ pyarrow==12.0.0
 redis==4.5.3
 torch==1.9.0+cpu
 transformers
-sentence_transformers==2.2.2 --install-option='--no-deps'
+sentence_transformers==2.2.2
 tqdm==4.64.1
 fakeredis


### PR DESCRIPTION
Since we're only using CPUs for inference for now, we don't need them for CI nor in the deployable artifact. Reduces build time from 4.5 --> 3.2 minutes. 